### PR TITLE
Add Docker usage instructions to README

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,48 @@
+name: Build and Push Docker Image
+
+on:
+  push:
+    branches: [ forppc2024, main ]
+  pull_request:
+    branches: [ forppc2024, main ]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to GitHub Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=ref,event=branch
+            type=sha,format=short
+            latest
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN apt-get update && apt-get install -y \
     build-essential \
     cmake \
     git \
+    python3-pip \
     libopencv-dev \
     libeigen3-dev \
     libyaml-cpp-dev \
@@ -46,6 +47,8 @@ RUN git clone https://github.com/ceres-solver/ceres-solver.git /opt/ceres-solver
     make -j$(nproc) && \
     make install && \
     ldconfig
+
+RUN pip install pandas gps_time
 
 # Create app directory
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,7 @@ RUN git clone https://github.com/ceres-solver/ceres-solver.git /opt/ceres-solver
     make install && \
     ldconfig
 
-RUN apt update && apt install python3-pip && pip install pandas gps_time
+RUN apt update && apt install python3-pip -y && pip install pandas gps_time
 
 # Create app directory
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,8 +41,10 @@ RUN git clone https://github.com/ceres-solver/ceres-solver.git /opt/ceres-solver
 # Create app directory
 WORKDIR /app
 
-# Copy source code
-COPY . .
+# Clone GICI-LIB repository
+RUN git clone https://github.com/inuex35/gici-open.git . && \
+    git checkout forppc2024 && \
+    git submodule update --init --recursive
 
 # Build GICI-LIB
 RUN mkdir -p build && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,7 @@ RUN git clone https://github.com/ceres-solver/ceres-solver.git /opt/ceres-solver
     make install && \
     ldconfig
 
-RUN pip install pandas gps_time
+RUN apt update && apt install python3-pip && pip install pandas gps_time
 
 # Create app directory
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,6 @@ RUN apt-get update && apt-get install -y \
     libopencv-dev \
     libeigen3-dev \
     libyaml-cpp-dev \
-    libgoogle-glog-dev \
     libgflags-dev \
     libatlas-base-dev \
     libsuitesparse-dev \
@@ -58,7 +57,9 @@ COPY . .
 # Build GICI-LIB
 RUN mkdir -p build && \
     cd build && \
-    cmake .. -DCMAKE_BUILD_TYPE=Release && \
+    cmake .. \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_PREFIX_PATH="/usr/local" && \
     make -j$(nproc)
 
 # Set the entrypoint

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,16 @@ RUN apt-get update && apt-get install -y \
     libsuitesparse-dev \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
+# Install Glog from source to ensure CMake config files are available
+RUN git clone https://github.com/google/glog.git /opt/glog && \
+    cd /opt/glog && \
+    git checkout v0.6.0 && \
+    mkdir build && cd build && \
+    cmake .. -DBUILD_SHARED_LIBS=ON -DBUILD_TESTING=OFF && \
+    make -j$(nproc) && \
+    make install && \
+    ldconfig
+
 # Install Ceres Solver
 RUN apt-get update && apt-get install -y \
     libgoogle-glog-dev \
@@ -36,15 +46,14 @@ RUN git clone https://github.com/ceres-solver/ceres-solver.git /opt/ceres-solver
     mkdir build && cd build && \
     cmake .. -DBUILD_TESTING=OFF -DBUILD_EXAMPLES=OFF && \
     make -j$(nproc) && \
-    make install
+    make install && \
+    ldconfig
 
 # Create app directory
 WORKDIR /app
 
-# Clone GICI-LIB repository
-RUN git clone https://github.com/inuex35/gici-open.git . && \
-    git checkout forppc2024 && \
-    git submodule update --init --recursive
+# Copy source code
+COPY . .
 
 # Build GICI-LIB
 RUN mkdir -p build && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,6 @@ RUN git clone https://github.com/google/glog.git /opt/glog && \
 
 # Install Ceres Solver
 RUN apt-get update && apt-get install -y \
-    libgoogle-glog-dev \
     libgflags-dev \
     libatlas-base-dev \
     libsuitesparse-dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,6 @@ RUN apt-get update && apt-get install -y \
     build-essential \
     cmake \
     git \
-    python3-pip \
     libopencv-dev \
     libeigen3-dev \
     libyaml-cpp-dev \
@@ -53,17 +52,4 @@ RUN pip install pandas gps_time
 # Create app directory
 WORKDIR /app
 
-# Copy source code
-COPY . .
-
-# Build GICI-LIB
-RUN mkdir -p build && \
-    cd build && \
-    cmake .. \
-        -DCMAKE_BUILD_TYPE=Release \
-        -DCMAKE_PREFIX_PATH="/usr/local" && \
-    make -j$(nproc)
-
-# Set the entrypoint
-ENTRYPOINT ["/app/build/gici_main"]
-CMD ["./option/tc.yaml"]
+CMD ["/bin/bash"]

--- a/README.md
+++ b/README.md
@@ -169,8 +169,8 @@ docker run -v /path/to/dataset:/data gici-lib ./option/nagoya1_tc.yaml
 公開されたイメージを利用する場合：
 
 ```bash
+# イメージをプル
 docker pull ghcr.io/inuex35/gici-open:latest
-docker run -v /path/to/dataset:/data ghcr.io/inuex35/gici-open:latest ./option/tc1.yaml
-```
 
-これにより、ローカルでのビルド作業を省略できます。
+# コンテナ内でbashシェルを起動
+docker run -it -v /path/to/dataset:/data ghcr.io/inuex35/gici-open:latest /bin/bash

--- a/README.md
+++ b/README.md
@@ -129,3 +129,48 @@ RTKLIBで可視化ができるのでconfig内のポートに接続してくだ�
 ## 7. ライセンス
 
 GICI-LIBは[GPL v3](https://www.gnu.org/licenses/gpl-3.0.html)のもとで配布されています。改変および配布は自由ですが、GPL v3の条件を満たす必要があります。
+
+---
+
+## 8. Docker による実行方法
+
+GICI-LIBはDockerを使用して簡単に実行することができます。環境構築の手間を省き、どのプラットフォームでも同じ結果を得ることができます。
+
+### 8.1 Dockerイメージのビルド
+
+リポジトリをクローンした後、以下のコマンドでDockerイメージをビルドします：
+
+```bash
+docker build -t gici-lib .
+```
+
+ビルドには環境によって10〜20分程度かかることがあります。
+
+### 8.2 Dockerコンテナの実行
+
+東京データセットの場合：
+
+```bash
+docker run -v /path/to/dataset:/data gici-lib ./option/tc1.yaml
+```
+
+名古屋データセットの場合：
+
+```bash
+docker run -v /path/to/dataset:/data gici-lib ./option/nagoya1_tc.yaml
+```
+
+注意：`/path/to/dataset`は実際のデータセットのパスに置き換えてください。
+
+### 8.3 GitHub Actions によるビルド
+
+このリポジトリにはGitHub Actionsの設定ファイル（`.github/workflows/docker-build.yml`）が含まれています。`forppc2024`または`main`ブランチへのプッシュ時に自動的にDockerイメージがビルドされ、GitHub Container Registryに公開されます。
+
+公開されたイメージを利用する場合：
+
+```bash
+docker pull ghcr.io/inuex35/gici-open:latest
+docker run -v /path/to/dataset:/data ghcr.io/inuex35/gici-open:latest ./option/tc1.yaml
+```
+
+これにより、ローカルでのビルド作業を省略できます。

--- a/README.md
+++ b/README.md
@@ -182,7 +182,5 @@ docker run -it -v $(pwd)/dataset:/app/dataset ghcr.io/inuex35/gici-open:latest /
 docker pull ghcr.io/inuex35/gici-open:latest
 
 # カレントディレクトリのデータセットをマウントしてbashシェルを起動
-docker run -it --rm \
-  -v ${PWD}:/app \
-  -w /app \
-  gici-dev /bin/bash/app/build/gici_main ./option/tc1.yaml
+docker run -it --rm -v ${PWD}:/app -w /app gici-dev /bin/bash
+/app/build/gici_main ./option/tc1.yaml

--- a/README.md
+++ b/README.md
@@ -182,5 +182,7 @@ docker run -it -v $(pwd)/dataset:/app/dataset ghcr.io/inuex35/gici-open:latest /
 docker pull ghcr.io/inuex35/gici-open:latest
 
 # カレントディレクトリのデータセットをマウントしてbashシェルを起動
-docker run -it -v ${PWD}/dataset:/app/dataset ghcr.io/inuex35/gici-open:latest /bin/bash
-/app/build/gici_main ./option/tc1.yaml
+docker run -it --rm \
+  -v ${PWD}:/app \
+  -w /app \
+  gici-dev /bin/bash/app/build/gici_main ./option/tc1.yaml

--- a/README.md
+++ b/README.md
@@ -146,20 +146,6 @@ docker build -t gici-lib .
 
 ビルドには環境によって10〜20分程度かかることがあります。
 
-### 8.2 Dockerコンテナの実行
-
-東京データセットの場合：
-
-```bash
-docker run -v /path/to/dataset:/data gici-lib ./option/tc1.yaml
-```
-
-名古屋データセットの場合：
-
-```bash
-docker run -v /path/to/dataset:/data gici-lib ./option/nagoya1_tc.yaml
-```
-
 注意：`/path/to/dataset`は実際のデータセットのパスに置き換えてください。
 
 ### 8.3 GitHub Actions によるビルド
@@ -171,16 +157,12 @@ docker run -v /path/to/dataset:/data gici-lib ./option/nagoya1_tc.yaml
 #### Ubuntu環境の場合
 
 ```bash
-# イメージをプル
-docker pull ghcr.io/inuex35/gici-open:latest
-
 # カレントディレクトリのデータセットをマウントしてbashシェルを起動
-docker run -it -v $(pwd)/dataset:/app/dataset ghcr.io/inuex35/gici-open:latest /bin/bash
+docker run -it --rm -v ${pwd}:/app -w /app gici-lib /bin/bash
+```
 
 #### Windows PowerShell環境の場合
-# イメージをプル
-docker pull ghcr.io/inuex35/gici-open:latest
-
+```
 # カレントディレクトリのデータセットをマウントしてbashシェルを起動
-docker run -it --rm -v ${PWD}:/app -w /app gici-dev /bin/bash
-/app/build/gici_main ./option/tc1.yaml
+docker run -it --rm -v ${PWD}:/app -w /app gici-lib /bin/bash
+```

--- a/README.md
+++ b/README.md
@@ -168,9 +168,19 @@ docker run -v /path/to/dataset:/data gici-lib ./option/nagoya1_tc.yaml
 
 公開されたイメージを利用する場合：
 
+#### Ubuntu環境の場合
+
 ```bash
 # イメージをプル
 docker pull ghcr.io/inuex35/gici-open:latest
 
-# コンテナ内でbashシェルを起動
-docker run -it -v /path/to/dataset:/data ghcr.io/inuex35/gici-open:latest /bin/bash
+# カレントディレクトリのデータセットをマウントしてbashシェルを起動
+docker run -it -v $(pwd)/dataset:/app/dataset ghcr.io/inuex35/gici-open:latest /bin/bash
+
+#### Windows PowerShell環境の場合
+# イメージをプル
+docker pull ghcr.io/inuex35/gici-open:latest
+
+# カレントディレクトリのデータセットをマウントしてbashシェルを起動
+docker run -it -v ${PWD}/dataset:/app/dataset ghcr.io/inuex35/gici-open:latest /bin/bash
+/app/build/gici_main ./option/tc1.yaml


### PR DESCRIPTION
# Docker サポートの追加

このPRでは、GICI-LIBにDockerサポートを追加し、より簡単にプロジェクトを実行できるようにします。

## 変更内容

1. **Dockerfile の追加**
   - Ubuntu 20.04 ベースイメージ
   - 必要なライブラリのインストール
   - GICI-LIBのビルド設定

2. **READMEの更新**
   - Docker を使用した実行方法の説明を追加

## 追加で必要な作業
GitHub Actionsによる自動ビルドを有効にするには、以下のファイルを作成する必要があります：
- `.github/workflows/docker-build.yml`

ファイルの内容は次のようになります：

```yaml
name: Build and Push Docker Image

on:
  push:
    branches: [ forppc2024, main ]
  pull_request:
    branches: [ forppc2024, main ]
  workflow_dispatch:

jobs:
  build:
    runs-on: ubuntu-latest
    steps:
      - name: Checkout code
        uses: actions/checkout@v3
        with:
          submodules: recursive

      - name: Set up Docker Buildx
        uses: docker/setup-buildx-action@v2

      - name: Login to GitHub Container Registry
        if: github.event_name != 'pull_request'
        uses: docker/login-action@v2
        with:
          registry: ghcr.io
          username: ${{ github.repository_owner }}
          password: ${{ secrets.GITHUB_TOKEN }}

      - name: Extract metadata for Docker
        id: meta
        uses: docker/metadata-action@v4
        with:
          images: ghcr.io/${{ github.repository }}
          tags: |
            type=ref,event=branch
            type=sha,format=short
            latest

      - name: Build and push Docker image
        uses: docker/build-push-action@v4
        with:
          context: .
          push: ${{ github.event_name != 'pull_request' }}
          tags: ${{ steps.meta.outputs.tags }}
          labels: ${{ steps.meta.outputs.labels }}
          cache-from: type=gha
          cache-to: type=gha,mode=max